### PR TITLE
Update dependencies.

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -5,7 +5,6 @@ var async = require('async');
 var bedrock = require('bedrock');
 var fs = require('fs');
 var mime = require('mime');
-var mkdirp = require('mkdirp');
 var path = require('path');
 var BedrockError = bedrock.util.BedrockError;
 
@@ -219,7 +218,7 @@ function _createDirectory(req, res, next) {
 
   async.auto({
     createDirectory: function(callback) {
-      mkdirp.mkdirp(dirPath, callback);
+      fs.mkdir(dirPath, {recursive: true}, callback);
     }}, function(err, result) {
     if(err) {
       return next(new BedrockError('Failed to create the directory.',

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-remote-filesystem",
   "dependencies": {
     "async": "^1.4.2",
-    "mime": "~1.2.11",
-    "mkdirp": "~0.5.0"
+    "mime": "~1.2.11"
   },
   "peerDependencies": {
     "bedrock": "^1.0.0"
@@ -36,5 +35,8 @@
   "devDependencies": {
     "request": "~2.51.0",
     "superagent": "~0.21.0"
+  },
+  "engines": {
+    "node": ">=10.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-remote-filesystem",
   "dependencies": {
     "async": "^1.4.2",
-    "mime": "~1.2.11"
+    "mime": "^1.4.1"
   },
   "peerDependencies": {
     "bedrock": "^1.0.0"
@@ -33,8 +33,8 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "request": "~2.51.0",
-    "superagent": "~0.21.0"
+    "request": "~2.68.0",
+    "superagent": "^3.7.0"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/tests/test.js
+++ b/tests/test.js
@@ -7,7 +7,6 @@
 var async = require('async');
 var bedrock = require('bedrock');
 var fs = require('fs');
-var mkdirp = require('mkdirp');
 var path = require('path');
 var request = require('request');
 var superagent = require('superagent');
@@ -26,7 +25,7 @@ describe('bedrock.services.filesystem', function() {
     before(function(done) {
       async.auto({
         createTestDir: function(callback) {
-          mkdirp(testDir, callback);
+          fs.mkdir(testDir, {recursive: true}, callback);
         },
         createTestFile: ['createTestDir', function(callback) {
           fs.writeFile(testFile, 'filesystem service test file', callback);


### PR DESCRIPTION
- Update mkdirp to native recursive mkdir API.
- Update dependencies to avoid security alerts.
- Changes untested. Doubtful anyone uses this package. Only release 0.0.1 was in 2015. If anyone needs a new release, many things need updating.